### PR TITLE
Update in-on practice database

### DIFF
--- a/src/dbs/in-on-practice.json
+++ b/src/dbs/in-on-practice.json
@@ -7,127 +7,377 @@
     {
       "question": "The meeting is ___ Monday.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "My birthday is ___ July.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "She was born ___ 1990.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "We will meet ___ the afternoon.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "The keys are ___ the table.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "He lives ___ New York.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "There is a stain ___ your shirt.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "My phone is ___ my pocket.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "He is lying ___ the bed.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "The cat is sleeping ___ the box.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "The picture is hanging ___ the wall.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "She works ___ the city center.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "I saw the movie ___ TV.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "We arrived ___ time.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "I'll see you ___ the morning.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "I like to read ___ the train.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "We visited Paris ___ 2022.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "The dog is ___ the garden.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "Write your name ___ the line.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "She put the dishes ___ the cupboard.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "I saw it ___ the newspaper.",
       "answer": "in",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "Let's meet ___ Tuesday.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "He drew a smiley face ___ the paper.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "The supermarket is ___ Elm Street.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
     },
     {
       "question": "The report is ___ my desk.",
       "answer": "on",
-      "choices": ["in", "on", "at", "by"]
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "She sat ___ the car.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The kids are playing ___ the yard.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "He's hiding ___ the closet.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "There's a spider ___ the bathroom.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "We stored the boxes ___ the attic.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "She works ___ an office downtown.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "My wallet is ___ my backpack.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "They arrived ___ the lobby.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The baby is asleep ___ the crib.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "I found it ___ the drawer.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "She sat ___ the front row.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "There's a fountain ___ the middle of the square.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "He lives ___ the south of Spain.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "We met ___ the center of town.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The city is located ___ the valley.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The store is ___ the corner of the mall.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "He got lost ___ the crowd.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "We were stuck ___ traffic.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "He was born ___ 1985.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The festival is ___ August.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "She usually relaxes ___ the evening.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "Winter begins ___ December.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "They moved here ___ 2015.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "She went abroad ___ 2003.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The museum opened ___ 1989.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "I'll finish it ___ an hour.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "He returned ___ two weeks.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The coffee spilled ___ the floor.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "Write the title ___ the top of the page.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "She placed her glasses ___ the shelf.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "There's dust ___ the window.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The label is ___ the bottle.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "I left a note ___ your desk.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The picture is ___ the ceiling.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "You can see the mountains ___ the horizon.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The number is printed ___ the ticket.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "The exam is ___ Monday morning.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "We celebrate Independence Day ___ July 4th.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "My appointment is ___ the 21st of March.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "She started the job ___ October.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "We met ___ Christmas Day.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "He graduated ___ 2012.",
+      "answer": "in",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "She will call you ___ Wednesday.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "They arrived ___ the weekend.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "Our anniversary is ___ June 30th.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "She left her book ___ the bus.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "We met ___ the train.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "I slept ___ the plane.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "They ate dinner ___ the ferry.",
+      "answer": "on",
+      "choices": ["in", "on"]
+    },
+    {
+      "question": "There is Wi-Fi ___ the coach.",
+      "answer": "on",
+      "choices": ["in", "on"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- standardize choice options to `in` or `on`
- add about 50 new practice questions for closed spaces, time periods, surfaces, days/dates and transportation

## Testing
- `npm run fmt`


------
https://chatgpt.com/codex/tasks/task_e_68772c3cc9d483209e769aa7fa24a70b