### PR TITLE
Add settings link in queries footer

### DIFF
--- a/src/layouts/MultiChoiceLayout.astro
+++ b/src/layouts/MultiChoiceLayout.astro
@@ -48,5 +48,12 @@ const { db, id, title, description } = Astro.props;
       class="underline text-blue-600 hover:text-blue-800"
       >Modifica los ejemplos aquí</a
     >.
+    <div class="mt-2">
+      <a
+        href={`${base}settings`}
+        class="underline text-blue-600 hover:text-blue-800"
+        aria-label="Go to settings">Settings</a
+      >
+    </div>
   </footer>
 </Layout>


### PR DESCRIPTION
## Summary
- add a link to the Settings page in the queries page footer

## Testing
- `npm run fmt`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c626ad3288320a75dc1f21e9f8c95