### PR TITLE
Add labels to question databases

### DIFF
--- a/src/components/dto/question.ts
+++ b/src/components/dto/question.ts
@@ -43,5 +43,6 @@ export type QuestionsDB = {
     | "multiple_choice_meaning"
     | "identify_phrasal_verb"
     | "error_correction";
+  labels?: string[];
   questions: Question[];
 };

--- a/src/dbs/english-spanish-restaurant-vocabulary.json
+++ b/src/dbs/english-spanish-restaurant-vocabulary.json
@@ -391,5 +391,6 @@
       "meaning": "Having a sharp, unpleasant taste.",
       "choices": ["amargo", "dulce", "picante", "salado"]
     }
-  ]
+  ],
+  "labels": ["vocabulary", "restaurant"]
 }

--- a/src/dbs/future-perfect-continuous.json
+++ b/src/dbs/future-perfect-continuous.json
@@ -41,5 +41,6 @@
     }
   ],
   "slug": "future-perfect-continuous",
-  "title": "Future Perfect Continuous"
+  "title": "Future Perfect Continuous",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/future-perfect.json
+++ b/src/dbs/future-perfect.json
@@ -46,5 +46,6 @@
     }
   ],
   "slug": "future-perfect",
-  "title": "Future Perfect"
+  "title": "Future Perfect",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/future-simple.json
+++ b/src/dbs/future-simple.json
@@ -31,5 +31,6 @@
     }
   ],
   "slug": "future-simple",
-  "title": "Future Simple"
+  "title": "Future Simple",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/in-on-at-practice.json
+++ b/src/dbs/in-on-at-practice.json
@@ -257,5 +257,6 @@
       "answer": "at",
       "choices": ["in", "on", "at"]
     }
-  ]
+  ],
+  "labels": ["prepositions"]
 }

--- a/src/dbs/in-on-practice.json
+++ b/src/dbs/in-on-practice.json
@@ -381,5 +381,6 @@
       "answer": "on",
       "choices": ["in", "on"]
     }
-  ]
+  ],
+  "labels": ["prepositions"]
 }

--- a/src/dbs/negative-imperative.json
+++ b/src/dbs/negative-imperative.json
@@ -116,5 +116,6 @@
       "answer": "Don't sit",
       "choices": ["Don't sit", "Don't sits", "Doesn't sit", "Sit not"]
     }
-  ]
+  ],
+  "labels": ["imperative"]
 }

--- a/src/dbs/past-continuous.json
+++ b/src/dbs/past-continuous.json
@@ -396,5 +396,6 @@
     }
   ],
   "slug": "past-continuous",
-  "title": "Past Continuous"
+  "title": "Past Continuous",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/past-perfect-continuous.json
+++ b/src/dbs/past-perfect-continuous.json
@@ -36,5 +36,6 @@
     }
   ],
   "slug": "past-perfect-continuous",
-  "title": "Past Perfect Continuous"
+  "title": "Past Perfect Continuous",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/past-perfect.json
+++ b/src/dbs/past-perfect.json
@@ -46,5 +46,6 @@
     }
   ],
   "slug": "past-perfect",
-  "title": "Past Perfect"
+  "title": "Past Perfect",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/past-simple-be.json
+++ b/src/dbs/past-simple-be.json
@@ -306,5 +306,6 @@
       "choices": ["was", "were", "is", "are"],
       "meaning": "Ellos fueron los campeones el año pasado."
     }
-  ]
+  ],
+  "labels": ["verb tense"]
 }

--- a/src/dbs/past-simple-negative.json
+++ b/src/dbs/past-simple-negative.json
@@ -391,5 +391,6 @@
     }
   ],
   "slug": "past-simple-negative",
-  "title": "Past Simple Negative"
+  "title": "Past Simple Negative",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/past-simple.json
+++ b/src/dbs/past-simple.json
@@ -31,5 +31,6 @@
     }
   ],
   "slug": "past-simple",
-  "title": "Past Simple"
+  "title": "Past Simple",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/personal-pronouns.json
+++ b/src/dbs/personal-pronouns.json
@@ -306,5 +306,6 @@
       "answer": "It",
       "choices": ["It", "He", "She", "They", "You", "We"]
     }
-  ]
+  ],
+  "labels": ["pronouns"]
 }

--- a/src/dbs/phrasal-verbs-get.json
+++ b/src/dbs/phrasal-verbs-get.json
@@ -578,5 +578,6 @@
     }
   ],
   "slug": "phrasal-verbs-get",
-  "title": "Phrasal Verbs With Get"
+  "title": "Phrasal Verbs With Get",
+  "labels": ["phrasal verbs"]
 }

--- a/src/dbs/phrasal-verbs-meanings.json
+++ b/src/dbs/phrasal-verbs-meanings.json
@@ -864,5 +864,6 @@
     }
   ],
   "slug": "phrasal-verbs-meanings",
-  "title": "Phrasal Verbs Meanings"
+  "title": "Phrasal Verbs Meanings",
+  "labels": ["phrasal verbs"]
 }

--- a/src/dbs/phrasal-verbs-out.json
+++ b/src/dbs/phrasal-verbs-out.json
@@ -226,5 +226,6 @@
     }
   ],
   "slug": "phrasal-verbs-out",
-  "title": "Phrasal Verbs with 'Out'"
+  "title": "Phrasal Verbs with 'Out'",
+  "labels": ["phrasal verbs"]
 }

--- a/src/dbs/phrasal-verbs-take.json
+++ b/src/dbs/phrasal-verbs-take.json
@@ -1172,5 +1172,6 @@
     }
   ],
   "slug": "phrasal-verbs-take",
-  "title": "Phrasal Verbs With Take"
+  "title": "Phrasal Verbs With Take",
+  "labels": ["phrasal verbs"]
 }

--- a/src/dbs/phrasal-verbs.json
+++ b/src/dbs/phrasal-verbs.json
@@ -507,5 +507,6 @@
     }
   ],
   "slug": "phrasal-verbs",
-  "title": "Phrasal Verbs"
+  "title": "Phrasal Verbs",
+  "labels": ["phrasal verbs"]
 }

--- a/src/dbs/prepositions-practice.json
+++ b/src/dbs/prepositions-practice.json
@@ -161,5 +161,6 @@
       "answer": "on",
       "choices": ["on", "in", "under", "behind", "next to", "between"]
     }
-  ]
+  ],
+  "labels": ["prepositions"]
 }

--- a/src/dbs/prepositions.json
+++ b/src/dbs/prepositions.json
@@ -808,5 +808,6 @@
         "on the subject of; concerning"
       ]
     }
-  ]
+  ],
+  "labels": ["prepositions"]
 }

--- a/src/dbs/present-continuous.json
+++ b/src/dbs/present-continuous.json
@@ -31,5 +31,6 @@
     }
   ],
   "slug": "present-continuous",
-  "title": "Present Continuous"
+  "title": "Present Continuous",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/present-perfect-continuous.json
+++ b/src/dbs/present-perfect-continuous.json
@@ -36,5 +36,6 @@
     }
   ],
   "slug": "present-perfect-continuous",
-  "title": "Present Perfect Continuous"
+  "title": "Present Perfect Continuous",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/present-perfect.json
+++ b/src/dbs/present-perfect.json
@@ -46,5 +46,6 @@
     }
   ],
   "slug": "present-perfect",
-  "title": "Present Perfect"
+  "title": "Present Perfect",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/present-simple-negative.json
+++ b/src/dbs/present-simple-negative.json
@@ -271,5 +271,6 @@
     }
   ],
   "slug": "present-simple-negative",
-  "title": "Present Simple Negative"
+  "title": "Present Simple Negative",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/present-simple.json
+++ b/src/dbs/present-simple.json
@@ -306,5 +306,6 @@
     }
   ],
   "slug": "present-simple",
-  "title": "Present Simple"
+  "title": "Present Simple",
+  "labels": ["verb tense"]
 }

--- a/src/dbs/schema.json
+++ b/src/dbs/schema.json
@@ -56,6 +56,14 @@
         "error_correction"
       ]
     },
+    "labels": {
+      "type": "array",
+      "title": "Labels",
+      "description": "Categories for grouping question sets.",
+      "items": {
+        "type": "string"
+      }
+    },
     "questions": {
       "type": "array",
       "title": "Preguntas",

--- a/src/dbs/spanish-household-vocabulary.json
+++ b/src/dbs/spanish-household-vocabulary.json
@@ -96,5 +96,6 @@
       "choices": ["bed", "sofa", "chair", "table", "desk"],
       "meaning": "A piece of furniture for sleeping or resting."
     }
-  ]
+  ],
+  "labels": ["vocabulary", "household"]
 }

--- a/src/dbs/spanish-restaurant-vocabulary.json
+++ b/src/dbs/spanish-restaurant-vocabulary.json
@@ -192,5 +192,6 @@
       "choices": ["bar", "restaurant", "market", "hotel", "school"],
       "meaning": "A place that serves alcoholic drinks."
     }
-  ]
+  ],
+  "labels": ["vocabulary", "restaurant"]
 }

--- a/src/dbs/this-that-practice.json
+++ b/src/dbs/this-that-practice.json
@@ -256,5 +256,6 @@
       "answer": "this",
       "choices": ["this", "that"]
     }
-  ]
+  ],
+  "labels": ["pronouns"]
 }

--- a/src/dbs/verb-to-be.json
+++ b/src/dbs/verb-to-be.json
@@ -111,5 +111,6 @@
       "answer": "are",
       "choices": ["am", "is", "are", "be"]
     }
-  ]
+  ],
+  "labels": ["verb tense"]
 }


### PR DESCRIPTION
## Summary
- include new `labels` attribute in DB schema and DTO
- categorize all question databases with `labels`

## Testing
- `npm run fmt`

------
https://chatgpt.com/codex/tasks/task_e_687e7b4ad11c8320ad1a267f63a8acbf