### PR TITLE
Add 150-question at/in/on practice database

### DIFF
--- a/src/dbs/at-in-on-practice-150.json
+++ b/src/dbs/at-in-on-practice-150.json
@@ -1,0 +1,762 @@
+{
+  "$schema": "./schema.json",
+  "title": "At, In, On Practice (150)",
+  "slug": "at-in-on-practice-150",
+  "language": "en",
+  "description": "Practice using at, in, and on with fill-in-the-blank questions.",
+  "questionType": "fill_in_the_blank",
+  "audioSupported": true,
+  "questions": [
+    {
+      "question": "The party is ___ Saturday night.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I was born ___ 1988.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She lives ___ London.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The meeting is ___ 2 PM.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We'll see you ___ the morning.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He left his keys ___ the table.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There's milk ___ the fridge.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I like to jog ___ the evening.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She arrived ___ the airport early.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "My birthday is ___ June.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The cat is sleeping ___ the sofa.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We met ___ the bus stop.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "They were married ___ 2010.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "Please sit ___ the table.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I hung the picture ___ the wall.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He usually wakes up ___ 7 o'clock.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "My office is ___ the second floor.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She enjoys swimming ___ the ocean.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I'll call you ___ lunchtime.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There is a spider ___ the ceiling.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She met him ___ 2015.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The show starts ___ 8 PM.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "They ate breakfast ___ bed.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We will meet ___ Monday afternoon.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The cookies are ___ the jar.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He put his books ___ his bag.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There's a crack ___ the window.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She left the notes ___ my desk.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I looked ___ the mirror.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The picture is ___ the top of the page.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We met ___ the train.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I like sitting ___ the garden.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He was waiting ___ the corner.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "My birthday is ___ the first of May.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She lives ___ 45 Main Street.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There's a fly ___ the ceiling.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I'll see you ___ the bus stop.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He got lost ___ the city.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The kids are playing ___ the yard.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She is lying ___ the beach.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The clock is ___ the wall.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I'll finish this ___ an hour.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We left the tickets ___ home.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There's a note ___ the bottom of the page.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I saw it ___ the newspaper.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I'll meet you ___ lunch.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The dog is sleeping ___ the floor.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She is waiting ___ the parking lot.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "Let's watch a movie ___ the evening.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He is good ___ playing the guitar.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The meeting is ___ Monday.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "My birthday is ___ July.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She was born ___ 1990.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We will meet ___ the afternoon.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The keys are ___ the table.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He lives ___ New York.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There is a stain ___ your shirt.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "My phone is ___ my pocket.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He is lying ___ the bed.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The cat is sleeping ___ the box.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The picture is hanging ___ the wall.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She works ___ the city center.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I saw the movie ___ TV.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We arrived ___ time.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I'll see you ___ the morning.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I like to read ___ the train.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We visited Paris ___ 2022.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The dog is ___ the garden.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "Write your name ___ the line.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She put the dishes ___ the cupboard.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I saw it ___ the newspaper.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "Let's meet ___ Tuesday.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He drew a smiley face ___ the paper.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The supermarket is ___ Elm Street.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The report is ___ my desk.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She sat ___ the car.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The kids are playing ___ the yard.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He's hiding ___ the closet.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There's a spider ___ the bathroom.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We stored the boxes ___ the attic.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She works ___ an office downtown.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "My wallet is ___ my backpack.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "They arrived ___ the lobby.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The baby is asleep ___ the crib.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I found it ___ the drawer.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She sat ___ the front row.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There's a fountain ___ the middle of the square.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He lives ___ the south of Spain.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We met ___ the center of town.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The city is located ___ the valley.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The store is ___ the corner of the mall.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He got lost ___ the crowd.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We were stuck ___ traffic.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He was born ___ 1985.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The festival is ___ August.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She usually relaxes ___ the evening.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "Winter begins ___ December.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "They moved here ___ 2015.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She went abroad ___ 2003.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The museum opened ___ 1989.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I'll finish it ___ an hour.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He returned ___ two weeks.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The coffee spilled ___ the floor.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "Write the title ___ the top of the page.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She placed her glasses ___ the shelf.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There's dust ___ the window.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The label is ___ the bottle.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I left a note ___ your desk.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The picture is ___ the ceiling.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "You can see the mountains ___ the horizon.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The number is printed ___ the ticket.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The exam is ___ Monday morning.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We celebrate Independence Day ___ July 4th.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "My appointment is ___ the 21st of March.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She started the job ___ October.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We met ___ Christmas Day.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He graduated ___ 2012.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She will call you ___ Wednesday.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "They arrived ___ the weekend.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "Our anniversary is ___ June 30th.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She left her book ___ the bus.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We met ___ the train.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I slept ___ the plane.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "They ate dinner ___ the ferry.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There is Wi-Fi ___ the coach.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He works ___ night.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We will meet ___ the station.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I have a meeting ___ 5 PM.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The train arrives ___ the morning.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She left her phone ___ the car.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "They moved here ___ May.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He likes to read ___ bed.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The conference is ___ September.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "My keys are ___ the kitchen table.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We were ___ the bus when it started raining.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "Let's meet ___ the entrance.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She is staying ___ a hotel downtown.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The cat is sleeping ___ the sofa again.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We eat dinner ___ the dining room.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I'll see you ___ Monday evening.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The picture hangs ___ the wall.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "She arrived ___ the last minute.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He put the groceries ___ the trunk.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "There's a note ___ the refrigerator.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "My friends live ___ a small town.",
+      "answer": "in",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "You can find it ___ the website.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "He usually relaxes ___ the weekend.",
+      "answer": "on",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "We will see each other ___ Christmas.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "The exhibition opens ___ 3 p.m.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    },
+    {
+      "question": "I parked the car ___ the corner.",
+      "answer": "at",
+      "choices": ["in", "on", "at"]
+    }
+  ],
+  "labels": ["prepositions"]
+}


### PR DESCRIPTION
## Summary
- add new dataset `at-in-on-practice-150.json` containing 150 fill-in-the-blank exercises for practicing `at`, `in`, and `on`

## Testing
- `npm run fmt`

------
https://chatgpt.com/codex/tasks/task_e_687ee48d47a88320a681761296053993