### PR TITLE
Add exam mode toggle with results

### DIFF
--- a/src/components/MultiChoice.tsx
+++ b/src/components/MultiChoice.tsx
@@ -107,8 +107,12 @@ const MultiChoice: React.FC<{ type: string; questions: Question[] }> = ({
     e?: React.MouseEvent<HTMLButtonElement>,
   ) => {
     answerCurrentQuestion(type, selectedAnswer);
-    // Only show confetti if animation is enabled and answer is correct
-    if (animationEnabled && selectedAnswer === currentQuestion.answer) {
+    // Mostrar confetti solo si la animación está habilitada, la respuesta es correcta y NO está en modo examen
+    if (
+      animationEnabled &&
+      selectedAnswer === currentQuestion.answer &&
+      !examMode
+    ) {
       if (e) {
         const { clientX, clientY, currentTarget } = e;
         // Calculate origin relative to viewport for canvas-confetti
@@ -140,6 +144,10 @@ const MultiChoice: React.FC<{ type: string; questions: Question[] }> = ({
   };
 
   const getButtonVariant = (choice: string) => {
+    // En modo examen y sin mostrar resultados, el seleccionado es gris (outline), sin feedback de correcto/incorrecto
+    if (examMode && !showResults) {
+      return "outline";
+    }
     if (!currentQuestion.selectedAnswer) return "outline";
 
     if (choice === currentQuestion.selectedAnswer) {
@@ -151,6 +159,13 @@ const MultiChoice: React.FC<{ type: string; questions: Question[] }> = ({
   };
 
   const getButtonClassName = (choice: string) => {
+    // En modo examen y sin mostrar resultados, el seleccionado es gris (bg-gray-300), sin feedback de correcto/incorrecto
+    if (examMode && !showResults) {
+      if (choice === currentQuestion.selectedAnswer) {
+        return "w-full mb-2 bg-gray-300 hover:bg-gray-400";
+      }
+      return "w-full mb-2";
+    }
     if (!currentQuestion.selectedAnswer) return "w-full mb-2";
 
     if (choice === currentQuestion.selectedAnswer) {

--- a/src/components/MultiChoice.tsx
+++ b/src/components/MultiChoice.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/stores/session";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import confetti from "canvas-confetti";
-import { animationStore } from "@/components/settings/store";
+import { animationStore, examModeStore } from "@/components/settings/store";
 import { SparklesText } from "./magicui/sparkles-text";
 
 const MultiChoice: React.FC<{ type: string; questions: Question[] }> = ({
@@ -27,6 +27,8 @@ const MultiChoice: React.FC<{ type: string; questions: Question[] }> = ({
   const progress = getSessionProgress(type);
   const stats = getSessionStats(type);
   const animationEnabled = useStore(animationStore);
+  const examMode = useStore(examModeStore);
+  const [showResults, setShowResults] = React.useState(false);
 
   // Detect desktop for UI (numeric labels)
   const [isDesktop, setIsDesktop] = React.useState(false);
@@ -163,16 +165,44 @@ const MultiChoice: React.FC<{ type: string; questions: Question[] }> = ({
 
   return (
     <div className="container mx-auto p-4">
+      {/* Exam mode controls */}
+      <div className="flex justify-end mb-4">
+        <Button
+          onClick={() => examModeStore.set(!examMode)}
+          variant={examMode ? "default" : "outline"}
+          size="sm"
+        >
+          {examMode ? "Salir de examen" : "Modo examen"}
+        </Button>
+        {examMode && (
+          <Button
+            onClick={() => setShowResults(!showResults)}
+            variant="secondary"
+            size="sm"
+            className="ml-2"
+          >
+            Resultados
+          </Button>
+        )}
+      </div>
       {/* Header with statistics */}
       <div className="mb-6 p-4 bg-gray-100 rounded-lg">
         <div className="flex justify-between items-center">
           <div className="text-sm text-gray-600">
             Question {progress.current} of {progress.total}
           </div>
-          <div className="text-sm text-gray-600">
-            Score: {stats.score}/{stats.totalQuestions} (
-            {stats.percentage.toFixed(1)}%)
-          </div>
+          {!examMode && (
+            <div className="text-sm text-gray-600">
+              Score: {stats.score}/{stats.totalQuestions} (
+              {stats.percentage.toFixed(1)}%)
+            </div>
+          )}
+          {examMode && showResults && (
+            <div className="text-sm text-gray-600">
+              Resultado: {stats.score}/{stats.totalQuestions} (
+              {stats.percentage.toFixed(1)}%)
+            </div>
+          )}
         </div>
         <div className="w-full bg-gray-200 rounded-full h-2 mt-2">
           <div
@@ -273,7 +303,7 @@ const MultiChoice: React.FC<{ type: string; questions: Question[] }> = ({
       </div>
 
       {/* Additional information if answered */}
-      {currentQuestion.selectedAnswer && (
+      {currentQuestion.selectedAnswer && (!examMode || showResults) && (
         <div className="p-4 bg-gray-50 rounded-lg">
           <div className="flex items-center justify-between">
             <span className="text-sm">

--- a/src/components/settings/store.ts
+++ b/src/components/settings/store.ts
@@ -9,3 +9,13 @@ export const animationStore = persistentAtom<boolean>(
     decode: (v) => v === "1",
   },
 );
+
+// Exam mode enabled: boolean
+export const examModeStore = persistentAtom<boolean>(
+  "settings:examMode",
+  false,
+  {
+    encode: (v) => (v ? "1" : "0"),
+    decode: (v) => v === "1",
+  },
+);


### PR DESCRIPTION
## Summary
- add `examModeStore` to settings
- allow toggling exam mode in `MultiChoice` and show results button when active

## Testing
- `npx prettier --write src/components/settings/store.ts src/components/MultiChoice.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f129f550c8320993525fa9c625e0b