### PR TITLE
feat: add exam mode toggle to SettingsForm component

### DIFF
--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -1,20 +1,31 @@
 import React from "react";
 import { useStore } from "@nanostores/react";
-import { animationStore } from "./store";
+import { animationStore, examModeStore } from "./store";
 
 const SettingsForm: React.FC = () => {
   const animationEnabled = useStore(animationStore);
+  const examModeEnabled = useStore(examModeStore);
   const [checked, setChecked] = React.useState(animationEnabled);
+  const [examChecked, setExamChecked] = React.useState(examModeEnabled);
 
   React.useEffect(() => {
     setChecked(animationEnabled);
   }, [animationEnabled]);
+  React.useEffect(() => {
+    setExamChecked(examModeEnabled);
+  }, [examModeEnabled]);
 
   // Persist immediately on toggle change
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setChecked(e.target.checked);
     animationStore.set(e.target.checked);
     console.log("Animation setting updated:", e.target.checked);
+  };
+
+  const handleExamChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setExamChecked(e.target.checked);
+    examModeStore.set(e.target.checked);
+    console.log("Exam mode setting updated:", e.target.checked);
   };
 
   return (
@@ -26,7 +37,7 @@ const SettingsForm: React.FC = () => {
             id="animation"
             name="animation"
             className="mr-2"
-            defaultChecked={checked}
+            checked={checked}
             onChange={handleChange}
           />
           Enable animations in MultiChoice forms
@@ -35,6 +46,25 @@ const SettingsForm: React.FC = () => {
           <p className="text-sm text-blue-800">
             If enabled, you will see a confetti animation when you answer
             correctly in MultiChoice exercises.
+          </p>
+        </div>
+      </div>
+      <div>
+        <label htmlFor="examMode" className="flex items-center">
+          <input
+            type="checkbox"
+            id="examMode"
+            name="examMode"
+            className="mr-2"
+            checked={examChecked}
+            onChange={handleExamChange}
+          />
+          Enable exam mode by default
+        </label>
+        <div className="mt-6 p-4 bg-yellow-50 rounded-lg border-l-4 border-yellow-400">
+          <p className="text-sm text-yellow-800">
+            If enabled, exercises will start in exam mode, hiding immediate
+            feedback until you choose to see results.
           </p>
         </div>
       </div>


### PR DESCRIPTION
This pull request enhances the `SettingsForm` component by introducing a new "Exam Mode" setting, allowing users to enable or disable exam mode directly from the settings interface. The changes include adding state management for the new setting, updating the UI to reflect the new option, and ensuring the state persists.

### New "Exam Mode" Setting:

* **State Management**: Added `examModeStore` to manage the state of the exam mode setting and integrated it with the component using `useStore`. State is synchronized with the UI through the `examChecked` state variable and updated via the `handleExamChange` function. (`src/components/settings/SettingsForm.tsx`, [[1]](diffhunk://#diff-2cb8bd1e2fb18d8d41f357d0229bab46f9671d75bfbafc0a9b68023134ef3b8aL3-R16) [[2]](diffhunk://#diff-2cb8bd1e2fb18d8d41f357d0229bab46f9671d75bfbafc0a9b68023134ef3b8aR25-R30)

* **UI Updates**: Added a new checkbox input for enabling/disabling exam mode, along with a descriptive label and a tooltip explaining its functionality. The checkbox state is tied to `examChecked`, ensuring it reflects the current setting. (`src/components/settings/SettingsForm.tsx`, [src/components/settings/SettingsForm.tsxR52-R70](diffhunk://#diff-2cb8bd1e2fb18d8d41f357d0229bab46f9671d75bfbafc0a9b68023134ef3b8aR52-R70))

* **Checkbox Behavior**: Updated the existing animation checkbox to use `checked` instead of `defaultChecked` for consistent state handling, aligning it with the new exam mode checkbox. (`src/components/settings/SettingsForm.tsx`, [src/components/settings/SettingsForm.tsxL29-R40](diffhunk://#diff-2cb8bd1e2fb18d8d41f357d0229bab46f9671d75bfbafc0a9b68023134ef3b8aL29-R40))