### PR TITLE
feat: index card with labels

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import Layout from "../layouts/Layout.astro";
 import { filterQuestionsDB } from "@/utils/filterQuestionsDB";
 import { arrayFromAsync } from "@/lib/arrayFromAsync";
 import { MagicCard } from "@/components/magicui/magic-card";
+import { Badge } from "@/components/ui/badge";
 import { questionTypeEmoji } from "@/lib/questionTypeEmoji";
 import classNames from "classnames";
 
@@ -79,6 +80,19 @@ const questionFiles: QuestionsDB[] = filterQuestionsDB(
                     <span class="block text-xs text-gray-500 mt-1">
                       {q.description}
                     </span>
+                  )}
+                  {Array.isArray(q.labels) && q.labels.length > 0 && (
+                    <div class="flex flex-wrap gap-1 mt-2">
+                      {q.labels.map((label) => (
+                        <Badge
+                          key={label}
+                          variant={"outline"}
+                          aria-label={`Label: ${label}`}
+                        >
+                          {label}
+                        </Badge>
+                      ))}
+                    </div>
                   )}
                 </div>
               </MagicCard>


### PR DESCRIPTION
This pull request introduces a new reusable `Badge` component and integrates it into the `index.astro` page to display labels for questions. The most important changes include the creation of the `Badge` component with customizable variants and its usage in the question list to render labels dynamically.

### Component creation:

* [`src/components/ui/badge.tsx`](diffhunk://#diff-6d99361c2e374eb2dd472d6136d9d5929c8f32128cbb0b6ab8bdafea6beca6aeR1-R46): Added a new `Badge` component with support for variant styles (`default`, `secondary`, `destructive`, and `outline`) using `class-variance-authority`. The component is designed to be flexible, supporting child components and additional styling through props.

### Component integration:

* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R7): Imported the `Badge` component and updated the question list to display labels using the `Badge` component. Labels are rendered as outlined badges when present, with accessibility features like `aria-label` for better usability. [[1]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R7) [[2]](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R84-R96)